### PR TITLE
Galera requires the binlog format to be ROW

### DIFF
--- a/galera-loader
+++ b/galera-loader
@@ -20,7 +20,8 @@ run(){
 	--pid-file=/var/run/mysqld/mysqld.pid \
 	--socket=/var/run/mysqld/mysqld.sock \
 	--port=3306 \
-	--wsrep_start_position=00000000-0000-0000-0000-000000000000:-1
+	--wsrep_start_position=00000000-0000-0000-0000-000000000000:-1 \
+	--binlog-format=row
 }
 
 backup_wait(){


### PR DESCRIPTION
> While binlog_format is checked on startup and can only be ROW (see
> Binary Log Formats), it can be changed at runtime. Do NOT change
> binlog_format at runtime, it is likely not only cause replication
> failure, but make all other nodes crash.
> -- https://mariadb.com/kb/en/mariadb/mariadb-galera-cluster-known-limitations/

Related Jira Ticket:
-- https://mariadb.atlassian.net/browse/MDEV-5490?jql=project%20%3D%20MDEV%20AND%20issuetype%20%3D%20Bug%20AND%20text%20~%20%22update%20deadlock%22
