### PR TITLE
Add xtrabackup to the image, update the apt sources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,15 +19,24 @@ ADD GPG-KEY-galeracluster.com /tmp/
 # install galera and everything we need
 # http://galeracluster.com/downloads/
 RUN apt-key add /tmp/GPG-KEY-galeracluster.com \
- && echo "deb http://releases.galeracluster.com/debian jessie main" \
+ && echo "deb http://releases.galeracluster.com/mysql-wsrep-5.6/debian jessie main" \
 	> /etc/apt/sources.list.d/galera.list \
- && package net-tools rsync dnsutils procps \
+ && echo "deb http://releases.galeracluster.com/galera-3/debian jessie main" \
+	>> /etc/apt/sources.list.d/galera.list \
+ && package net-tools rsync dnsutils procps lsof \
     mysql-wsrep-server-5.6=5.6.* galera-3=25* galera-arbitrator-3=25* \
  && sed -i '/error.log/d' /etc/mysql/my.cnf \
  && rm /var/log/mysql/error.log \
  && echo '!includedir /etc/mysql/ssl.d/' >> /etc/mysql/my.cnf \
  && mkdir /etc/mysql/ssl.d \
- && rm /var/lib/mysql/ib_logfile*
+ && rm /var/lib/mysql/ib_logfile* \
+ && sed -i 's|^log-error.*$||' /etc/mysql/mysql.conf.d/mysqld.cnf
+# last line removes the log-error line from the mysqld.conf which prevented logging to console
+
+ADD https://repo.percona.com/apt/percona-release_0.1-6.jessie_all.deb percona-release_0.1-6.jessie_all.deb
+
+RUN dpkg -i percona-release_0.1-6.jessie_all.deb \
+ && package percona-xtrabackup-24
 
 # Copy in our loader
 ADD galera-loader /galera-loader

--- a/galera-loader
+++ b/galera-loader
@@ -4,6 +4,7 @@ set -ueo pipefail
 log(){
 	echo "$(date +"%F %H:%M:%S") $1"
 }
+
 run(){
 	chown -R mysql: /var/lib/mysql
 	exec /usr/sbin/mysqld \
@@ -96,7 +97,7 @@ if [ "${1:-}" = "garbd" ]; then
 fi
 
 if [ -e /etc/mysql/conf.d/runtime.cnf ]; then
-	# This is our first run.
+	# This is not our first run.
 	run
 fi
 
@@ -116,6 +117,22 @@ wsrep_cluster_address=gcomm://$PEERS
 wsrep_provider=/usr/lib/galera/libgalera_smm.so
 max_connections="${MAX_CONNECTIONS}"
 performance_schema = off
+
+# INNODB #
+innodb-flush-method            = O_DIRECT
+innodb-log-files-in-group      = 2
+innodb-log-file-size           = 512M
+innodb-flush-log-at-trx-commit = 2
+
+# CACHES AND LIMITS #
+tmp-table-size                 = 32M
+max-heap-table-size            = 32M
+query-cache-type               = 0
+query-cache-size               = 0
+thread-cache-size              = 100
+open-files-limit               = 65535
+table-definition-cache         = 1024
+table-open-cache               = 2048
 dog
 
 if [ -n "$MYSQL_ROOT_PASSWORD" ]; then


### PR DESCRIPTION
SURPRISE. Bet you didn't think you'd see updates to this container. JK I'm sure you did.

* The galeracluster apt repos for wsrep and galera have moved.
* The latest version of mysql 5.6 puts a `log-error` line into `/etc/mysql/mysql.conf.d/mysqld.cnf` which prevents logging to the console (as our `runtime.cnf` is evaluated before `mysqld.cnf`).
* To set the percona debian repos, you install a deb and that deb sets your apt sources 🤷‍♂️ 
* Set some more sane defaults for the `runtime.cnf`.
* Install percona xtrabackup, as it's very different and not compatible with the current backup scripts, I just left those along and you can call out to xtrabackup. But apparently it needs access to the unix socket for backing up :(

I won't be upset if you don't approve or want to merge this. But I thought I'd contribute upstream if you wanted it.